### PR TITLE
Making TypeRig panels fit vertically into a MacBook Pro screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
-*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.eggs/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.idea/

--- a/Lib/typerig/QtGui.py
+++ b/Lib/typerig/QtGui.py
@@ -1,0 +1,24 @@
+from PythonQt.QtGui import *
+from platform import system
+
+MAC_VSPACING = 3
+
+class QDialog(QDialog):
+	def __init__(self):
+		super(QDialog, self).__init__()
+		if system() == 'Darwin':
+			self.setStyleSheet("font-size: 11px;")
+
+class QGridLayout(QGridLayout):
+	def __init__(self):
+		super(QGridLayout, self).__init__()
+		if system() == 'Darwin':
+			self.setVerticalSpacing(MAC_VSPACING)
+			self.setContentsMargins(10,3,10,3)
+
+class QVBoxLayout(QVBoxLayout):
+	def __init__(self):
+		super(QVBoxLayout, self).__init__()
+		if system() == 'Darwin':
+			self.setSpacing(MAC_VSPACING)
+			self.setContentsMargins(10,3,10,3)

--- a/Scripts/TypeRig GUI/Filter/Corner.py
+++ b/Scripts/TypeRig GUI/Filter/Corner.py
@@ -15,7 +15,8 @@ from collections import OrderedDict
 
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pFont, pShape, pNode, pWorkspace
 from typerig.node import eNode
 from typerig.glyph import eGlyph

--- a/Scripts/TypeRig GUI/Manager/FontMetrics.py
+++ b/Scripts/TypeRig GUI/Manager/FontMetrics.py
@@ -16,7 +16,8 @@ app_name, app_version = 'TypeRig | Font Metrics', '0.12'
 import os, json
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pGlyph, pFont
 from typerig.gui import trTableView
 

--- a/Scripts/TypeRig GUI/Manager/KernGroups.py
+++ b/Scripts/TypeRig GUI/Manager/KernGroups.py
@@ -17,7 +17,8 @@ alt_mark = '.'
 import os, json
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pFont, pGlyph
 from typerig.utils import getUppercaseCodepoint, getLowercaseCodepoint
 

--- a/Scripts/TypeRig GUI/Manager/__Anchors.py
+++ b/Scripts/TypeRig GUI/Manager/__Anchors.py
@@ -16,7 +16,8 @@ app_name, app_version = 'TypeRig | Anchors', '0.01'
 import os, json
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pGlyph, pFont
 from collections import defaultdict
 

--- a/Scripts/TypeRig GUI/Manager/__Instances.py
+++ b/Scripts/TypeRig GUI/Manager/__Instances.py
@@ -16,7 +16,8 @@ app_name, app_version = 'TypeRig | Font Metrics', '0.11'
 import os, json
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pGlyph, pFont
 
 # - Sub widgets ------------------------

--- a/Scripts/TypeRig GUI/Panel/Anchor.py
+++ b/Scripts/TypeRig GUI/Panel/Anchor.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.gui import getProcessGlyphs
 

--- a/Scripts/TypeRig GUI/Panel/Curve.py
+++ b/Scripts/TypeRig GUI/Panel/Curve.py
@@ -17,7 +17,8 @@ app_name, app_version = 'TypeRig | Curves', '0.10'
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.node import eNode
 from typerig.curve import eCurveEx

--- a/Scripts/TypeRig GUI/Panel/Guide.py
+++ b/Scripts/TypeRig GUI/Panel/Guide.py
@@ -17,7 +17,8 @@ app_name, app_version = 'TypeRig | Guidelines', '0.34'
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.proxy import pFontMetrics, pFont, pGlyph, pWorkspace
 

--- a/Scripts/TypeRig GUI/Panel/Layer.py
+++ b/Scripts/TypeRig GUI/Panel/Layer.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.gui import trSliderCtrl
 from itertools import groupby

--- a/Scripts/TypeRig GUI/Panel/Metrics.py
+++ b/Scripts/TypeRig GUI/Panel/Metrics.py
@@ -17,7 +17,8 @@ app_name, app_version = 'TypeRig | Metrics', '0.22'
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.gui import getProcessGlyphs
 

--- a/Scripts/TypeRig GUI/Panel/Mixer.py
+++ b/Scripts/TypeRig GUI/Panel/Mixer.py
@@ -24,7 +24,8 @@ from math import radians
 
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 
 from typerig.proxy import pFont
 from typerig.glyph import eGlyph

--- a/Scripts/TypeRig GUI/Panel/Node.py
+++ b/Scripts/TypeRig GUI/Panel/Node.py
@@ -17,7 +17,8 @@ app_name, app_version = 'TypeRig | Nodes', '0.66'
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.node import eNode
 from typerig.contour import eContour

--- a/Scripts/TypeRig GUI/Panel/Outline.py
+++ b/Scripts/TypeRig GUI/Panel/Outline.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.node import eNode
 from typerig.gui import trTableView

--- a/Scripts/TypeRig GUI/Panel/Stats.py
+++ b/Scripts/TypeRig GUI/Panel/Stats.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pFont, pWorkspace
 from typerig.glyph import eGlyph
 from typerig.gui import trTableView

--- a/Scripts/TypeRig GUI/Panel/String.py
+++ b/Scripts/TypeRig GUI/Panel/String.py
@@ -30,7 +30,8 @@ filler_patterns = [	'FL A FR',
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.proxy import pFont
 from typerig.string import stringGen, strRepDict, fillerList, baseGlyphset
 

--- a/Scripts/TypeRig GUI/Panel/TextBock.py
+++ b/Scripts/TypeRig GUI/Panel/TextBock.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 import cPickle, os
 
 from typerig.proxy import pWorkspace, pTextBlock, pFont

--- a/Scripts/TypeRig GUI/Panel/__Anchor-Test.py
+++ b/Scripts/TypeRig GUI/Panel/__Anchor-Test.py
@@ -10,7 +10,8 @@
 # - Dependencies -----------------
 import fontlab as fl6
 import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 from typerig.glyph import eGlyph
 from typerig.gui import getProcessGlyphs
 from collections import defaultdict

--- a/Scripts/TypeRig GUI/typerig-filter.py
+++ b/Scripts/TypeRig GUI/typerig-filter.py
@@ -11,10 +11,11 @@
 # - Dependencies -----------------
 #import fontlab as fl6
 #import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 
-# -- Internals - Load toolpanels 
-import Filter as Panel 
+# -- Internals - Load toolpanels
+import Filter as Panel
 
 # - Init --------------------------
 app_version = '0.25'
@@ -29,9 +30,9 @@ ss_Toolbox_none = """/* EMPTY STYLESHEET */ """
 class typerig_filter(QtGui.QDialog):
 	def __init__(self):
 		super(typerig_filter, self).__init__()
-	
-		self.setStyleSheet(ss_Toolbox_none)
-		
+
+		#self.setStyleSheet(ss_Toolbox_none)
+
 		# - Layers --------------------------
 		self.chk_ActiveLayer = QtGui.QCheckBox('Active')
 		self.chk_Masters = QtGui.QCheckBox('Masters')
@@ -40,7 +41,7 @@ class typerig_filter(QtGui.QDialog):
 
 		self.chk_ActiveLayer.setCheckState(QtCore.Qt.Checked)
 		#self.chk_ActiveLayer.setStyleSheet('QCheckBox::indicator:checked {background-color: limegreen; border: 1px Solid limegreen;}')
-			
+
 		self.chk_ActiveLayer.stateChanged.connect(self.refreshLayers)
 		self.chk_Masters.stateChanged.connect(self.refreshLayers)
 		self.chk_Masks.stateChanged.connect(self.refreshLayers)
@@ -58,7 +59,7 @@ class typerig_filter(QtGui.QDialog):
 		self.rad_window.toggled.connect(self.refreshMode)
 		self.rad_selection.toggled.connect(self.refreshMode)
 		self.rad_font.toggled.connect(self.refreshMode)
-		
+
 		self.rad_glyph.setChecked(True)
 
 		self.rad_glyph.setEnabled(True)
@@ -74,7 +75,7 @@ class typerig_filter(QtGui.QDialog):
 		# - Fold Button ---------------------
 		self.btn_fold = QtGui.QPushButton('^')
 		self.btn_unfold = QtGui.QPushButton('Restore Panel')
-		
+
 		self.btn_fold.setFixedHeight(self.chk_ActiveLayer.sizeHint.height()*2.5)
 		self.btn_fold.setFixedWidth(self.chk_ActiveLayer.sizeHint.height())
 		self.btn_unfold.setFixedHeight(self.chk_ActiveLayer.sizeHint.height() + 5)
@@ -85,26 +86,26 @@ class typerig_filter(QtGui.QDialog):
 		self.btn_fold.clicked.connect(self.fold)
 		self.btn_unfold.clicked.connect(self.fold)
 		self.flag_fold = False
-				
+
 		# - Tabs --------------------------
 		# -- Dynamically load all tabs
 		self.tabs = QtGui.QTabWidget()
 		self.tabs.setTabPosition(QtGui.QTabWidget.East)
 
-		# --- Load all tabs from this directory as modules. Check __init__.py 
+		# --- Load all tabs from this directory as modules. Check __init__.py
 		# --- <dirName>.modules tabs/modules manifest in list format
 		for toolName in Panel.modules:
 			if ignorePanel not in toolName:
 				self.tabs.addTab(eval('Panel.%s.tool_tab()' %toolName), toolName)
-		
+
 		# - Layouts -------------------------------
-		layoutV = QtGui.QVBoxLayout() 
+		layoutV = QtGui.QVBoxLayout()
 		layoutV.setContentsMargins(0,0,0,0)
-		
+
 		self.lay_controller = QtGui.QGridLayout()
 		self.fr_controller = QtGui.QFrame()
-		self.lay_controller.setContentsMargins(15,10,5,5)
-				
+		self.lay_controller.setContentsMargins(15,5,5,3)
+
 		# -- Build layouts -------------------------------
 		self.lay_controller.addWidget(self.chk_ActiveLayer,	0, 0, 1, 1)
 		self.lay_controller.addWidget(self.chk_Masters, 	0, 1, 1, 1)
@@ -115,10 +116,10 @@ class typerig_filter(QtGui.QDialog):
 		self.lay_controller.addWidget(self.rad_window, 		1, 1, 1, 1)
 		self.lay_controller.addWidget(self.rad_selection, 	1, 2, 1, 1)
 		self.lay_controller.addWidget(self.rad_font, 		1, 3, 1, 1)
-					 
+
 		layoutV.addWidget(self.btn_unfold)
 		self.fr_controller.setLayout(self.lay_controller)
-		
+
 		layoutV.addWidget(self.fr_controller)
 		layoutV.addWidget(self.tabs)
 
@@ -130,20 +131,20 @@ class typerig_filter(QtGui.QDialog):
 		self.setGeometry(300, 300, 240, 440)
 		self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint) # Always on top!!
 		#self.setMinimumWidth(300)
-		
+
 		self.show()
 
 	def refreshLayers(self):
 		global pLayers
 		pLayers = (self.chk_ActiveLayer.isChecked(), self.chk_Masters.isChecked(), self.chk_Masks.isChecked(), self.chk_Service.isChecked())
-		
+
 		for toolName in Panel.modules:
 			exec('Panel.%s.pLayers = %s' %(toolName, pLayers))
 
 	def refreshMode(self):
 		global pMode
 		pMode = 0
-		
+
 		if self.rad_glyph.isChecked(): pMode = 0
 		if self.rad_window.isChecked(): pMode = 1
 		if self.rad_selection.isChecked(): pMode = 2
@@ -158,7 +159,7 @@ class typerig_filter(QtGui.QDialog):
 		height_folded = self.btn_unfold.sizeHint.height()
 		height_expanded = self.tabs.sizeHint.height() + 40 #Fix this! + 40 Added because Nodes tab breaks
 		#self.resize(QtCore,Qsize(width_all, height_folded))
-		
+
 		# - Do
 		if not self.flag_fold:
 			self.tabs.hide()
@@ -168,19 +169,18 @@ class typerig_filter(QtGui.QDialog):
 			self.setFixedHeight(height_folded)
 			self.flag_fold = True
 		else:
-			self.setFixedHeight(height_expanded) 
+			self.setFixedHeight(height_expanded)
 			self.tabs.show()
 			self.fr_controller.show()
 			self.btn_unfold.hide()
 			self.repaint()
 			self.flag_fold = False
-	
+
 # - STYLE OVERRIDE -------------------
 # -- Following (uncommented) will override the default OS styling for Qt Widgets on Mac OS.
 from platform import system
 if system() == 'Darwin':
-	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('Fusion')) # Options: Windows, WindowsXP, WindowsVista, Fusion
+	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('macintosh')) # Options: Windows, WindowsXP, WindowsVista, Fusion
 
 # - RUN ------------------------------
 dialog = typerig_filter()
-

--- a/Scripts/TypeRig GUI/typerig-manager.py
+++ b/Scripts/TypeRig GUI/typerig-manager.py
@@ -11,7 +11,8 @@
 # - Dependencies -----------------
 #import fontlab as fl6
 #import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 
 # -- Internals - Load toolpanels 
 import Manager
@@ -30,7 +31,7 @@ class typerig_Manager(QtGui.QDialog):
 	def __init__(self):
 		super(typerig_Manager, self).__init__()
 	
-		self.setStyleSheet(ss_Toolbox_none)
+		#self.setStyleSheet(ss_Toolbox_none)
 				
 		# - Tabs --------------------------
 		# -- Dynamically load all tabs
@@ -48,8 +49,8 @@ class typerig_Manager(QtGui.QDialog):
 		layoutV.setContentsMargins(0,0,0,0)
 		
 		self.lay_layers = QtGui.QGridLayout()
-		self.lay_layers.setContentsMargins(15,10,5,5)
-				
+		self.lay_layers.setContentsMargins(15,5,5,3)
+
 		# -- Build layouts -------------------------------
 		layoutV.addWidget(self.tabs)
 
@@ -65,7 +66,7 @@ class typerig_Manager(QtGui.QDialog):
 # -- Following (uncommented) will override the default OS styling for Qt Widgets on Mac OS.
 from platform import system
 if system() == 'Darwin':
-	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('Fusion')) # Options: Windows, WindowsXP, WindowsVista, Fusion
+	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('macintosh')) # Options: Windows, WindowsXP, WindowsVista, Fusion
 
 # - RUN ------------------------------
 dialog = typerig_Manager()

--- a/Scripts/TypeRig GUI/typerig-panel.py
+++ b/Scripts/TypeRig GUI/typerig-panel.py
@@ -11,7 +11,8 @@
 # - Dependencies -----------------
 #import fontlab as fl6
 #import fontgate as fgt
-from PythonQt import QtCore, QtGui
+from PythonQt import QtCore
+from typerig import QtGui
 
 # -- Internals - Load toolpanels 
 import Panel 
@@ -29,8 +30,8 @@ ss_Toolbox_none = """/* EMPTY STYLESHEET */ """
 class typerig_Panel(QtGui.QDialog):
 	def __init__(self):
 		super(typerig_Panel, self).__init__()
-	
-		self.setStyleSheet(ss_Toolbox_none)
+
+		#self.setStyleSheet(ss_Toolbox_none)
 		
 		# - Layers --------------------------
 		self.chk_ActiveLayer = QtGui.QCheckBox('Active')
@@ -103,8 +104,9 @@ class typerig_Panel(QtGui.QDialog):
 		
 		self.lay_controller = QtGui.QGridLayout()
 		self.fr_controller = QtGui.QFrame()
-		self.lay_controller.setContentsMargins(15,10,5,5)
-				
+		self.lay_controller.setContentsMargins(15,5,5,3)
+		self.lay_controller.setSpacing(5)
+
 		# -- Build layouts -------------------------------
 		self.lay_controller.addWidget(self.chk_ActiveLayer,	0, 0, 1, 1)
 		self.lay_controller.addWidget(self.chk_Masters, 	0, 1, 1, 1)
@@ -179,7 +181,7 @@ class typerig_Panel(QtGui.QDialog):
 # -- Following (uncommented) will override the default OS styling for Qt Widgets on Mac OS.
 from platform import system
 if system() == 'Darwin':
-	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('Fusion')) # Options: Windows, WindowsXP, WindowsVista, Fusion
+	QtGui.QApplication.setStyle(QtGui.QStyleFactory.create('macintosh')) # Options: Windows, WindowsXP, WindowsVista, Fusion
 
 # - RUN ------------------------------
 dialog = typerig_Panel()


### PR DESCRIPTION
This addresses https://github.com/kateliev/TypeRig/issues/17

The result is a very compact appearance on the Mac — but everything fits: 

<img width="483" alt="scr- 2019-08-26 at 04 10 47" src="https://user-images.githubusercontent.com/519108/63660864-9b01b100-c7b8-11e9-88f2-7e5ca9241ca1.PNG">

It’s implemented via a new typerig.QtGui module which acts as an adapter of the standard QtGui classes. Currently, it’s not very sophisticated — could be improved. But it’s better than the ugly hack with loading Fusion styling. 